### PR TITLE
Harden gof init for paths, Postgres ports, and failed-run cleanup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: `gof` CLI - Go application code generator
 - Primary audience: LLM agents working on CLI development
-- Last updated: 2026-03-10
+- Last updated: 2026-07-23
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 
@@ -325,6 +325,7 @@ cmd/gof/
 ├── cmd/
 │   ├── root.go                # Root Cobra command
 │   ├── init.go                # gof init - project scaffolding
+│   ├── init_helpers.go        # init path/name parse, postgres port, rollback helpers
 │   ├── model.go               # gof model - CRUD generation orchestrator (560 lines)
 │   ├── model_db.go            # Proto, SQL migration, SQLC query generation
 │   ├── model_service.go       # Service + transport + validation generation
@@ -370,7 +371,7 @@ Related files outside `cmd/gof/`:
 
 | Command | Purpose |
 |---------|---------|
-| `gof init <name>` | Scaffold new project |
+| `gof init <path-or-name> [--postgres-port N]` | Scaffold new project |
 | `gof model <name> <col:type...>` | Generate CRUD model with all layers |
 | `gof client svelte` | Add Svelte frontend |
 | `gof client tanstack` | Add TanStack frontend |
@@ -640,7 +641,7 @@ Known gaps:
 ```go
 // Config
 config.ParseConfig() (*Config, error)
-config.Initialize(projectName string) error
+config.Initialize(projectDir, projectName string) error
 config.AddModel(name string, columns []Column) error
 config.AddIntegration(name string) error
 config.HasService(name string) bool
@@ -660,7 +661,7 @@ integrations.MergeConfigMarkers(srcConfig, dstConfig, integration string) error
 integrations.StripOtherIntegrations(projectPath string, keep string) error
 
 // Repo
-repo.DownloadRepo(email, apiKey, projectName string) error
+repo.DownloadRepo(email, apiKey, projectDir string) error
 
 // E2E
 e2e.GenerateClientE2ETest(modelName string, columns []config.Column) error

--- a/cmd/gof/cmd/init.go
+++ b/cmd/gof/cmd/init.go
@@ -16,7 +16,10 @@ import (
 
 func init() {
 	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().IntVar(&postgresPort, "postgres-port", defaultPostgresHostPort, "Host port published for PostgreSQL")
 }
+
+var postgresPort int
 
 var initCmd = &cobra.Command{
 	Use:   "init [project_name]",
@@ -39,7 +42,6 @@ var initCmd = &cobra.Command{
 			}
 		}
 
-		// Check for docker-compose
 		if _, err := exec.LookPath("docker"); err == nil {
 			if err := exec.Command("docker", "compose", "version").Run(); err != nil {
 				missingDeps = append(missingDeps, "docker compose")
@@ -60,84 +62,121 @@ var initCmd = &cobra.Command{
 			cmd.Printf("Authentication failed: %v.\n", err)
 			return
 		}
-		projectName := args[0]
-		if projectName == "" {
-			cmd.Println("Project name cannot be empty.")
+
+		projectDir, projectName, err := parseProjectArg(args[0])
+		if err != nil {
+			cmd.Printf("%v\n", err)
 			return
 		}
-		// check if the project directory already exists
-		_, err = os.Stat(projectName)
-		if err == nil {
-			cmd.Printf("Project directory '%s' already exists. Please choose a different name.\n", projectName)
+
+		if _, err = os.Stat(projectDir); err == nil {
+			cmd.Printf("Project directory '%s' already exists. Please choose a different name.\n", projectDir)
 			return
 		}
-		// download the repository
-		err = repo.DownloadRepo(email, apiKey, projectName)
+
+		if postgresPort < 1 || postgresPort > 65535 {
+			cmd.Printf("Invalid --postgres-port %d: must be between 1 and 65535.\n", postgresPort)
+			return
+		}
+		if hostPortInUse(postgresPort) {
+			suggested := suggestFreePostgresPort()
+			cmd.Printf("Port %d is already in use.\n", postgresPort)
+			cmd.Printf("Retry with: gof init %s --postgres-port %d\n", args[0], suggested)
+			return
+		}
+
+		err = repo.DownloadRepo(email, apiKey, projectDir)
 		if err != nil {
 			cmd.Printf("Error downloading repository: %v\n", err)
 			return
 		}
-		if err := os.RemoveAll(filepath.Join(projectName, ".git")); err != nil {
+
+		success := false
+		defer func() {
+			if !success {
+				rollbackProject(projectDir)
+				cmd.Printf("Removed partial project at '%s'.\n", projectDir)
+			}
+		}()
+
+		if err := os.RemoveAll(filepath.Join(projectDir, ".git")); err != nil {
 			cmd.Printf("Warning: could not remove template git metadata: %v\n", err)
 		}
 		// remove template-only folders and files
 		for _, client := range clients.All() {
-			if err := os.RemoveAll(filepath.Join(projectName, "app", client.ServiceDir)); err != nil {
+			if err := os.RemoveAll(filepath.Join(projectDir, "app", client.ServiceDir)); err != nil {
 				cmd.Printf("Warning: could not remove initial %s client folder: %v\n", client.DisplayName, err)
 			}
 		}
-		if err := os.RemoveAll(filepath.Join(projectName, "monitoring")); err != nil {
+		if err := os.RemoveAll(filepath.Join(projectDir, "monitoring")); err != nil {
 			cmd.Printf("Warning: could not remove monitoring folder: %v\n", err)
 		}
-		if err := os.RemoveAll(filepath.Join(projectName, "infra")); err != nil {
+		if err := os.RemoveAll(filepath.Join(projectDir, "infra")); err != nil {
 			cmd.Printf("Warning: could not remove infra folder: %v\n", err)
 		}
-		if err := os.Remove(filepath.Join(projectName, "docker-compose.monitoring.yml")); err != nil && !os.IsNotExist(err) {
+		if err := os.Remove(filepath.Join(projectDir, "docker-compose.monitoring.yml")); err != nil && !os.IsNotExist(err) {
 			cmd.Printf("Warning: could not remove monitoring docker compose file: %v\n", err)
 		}
 		for _, client := range clients.All() {
-			if err := os.Remove(filepath.Join(projectName, client.ComposeFile)); err != nil && !os.IsNotExist(err) {
+			if err := os.Remove(filepath.Join(projectDir, client.ComposeFile)); err != nil && !os.IsNotExist(err) {
 				cmd.Printf("Warning: could not remove %s docker compose file: %v\n", client.DisplayName, err)
 			}
 		}
-		if err := os.RemoveAll(filepath.Join(projectName, "e2e")); err != nil {
+		if err := os.RemoveAll(filepath.Join(projectDir, "e2e")); err != nil {
 			cmd.Printf("Warning: could not remove e2e folder: %v\n", err)
 		}
-		if err := os.RemoveAll(filepath.Join(projectName, ".github")); err != nil {
+		if err := os.RemoveAll(filepath.Join(projectDir, ".github")); err != nil {
 			cmd.Printf("Warning: could not remove .github folder: %v\n", err)
 		}
 		// Strip optional integrations - user can add them back with 'gof add <integration>'
-		if err := integrations.StripeStrip(projectName); err != nil {
+		if err := integrations.StripeStrip(projectDir); err != nil {
 			cmd.Printf("Error stripping stripe: %v\n", err)
 			return
 		}
-		if err := integrations.S3Strip(projectName); err != nil {
+		if err := integrations.S3Strip(projectDir); err != nil {
 			cmd.Printf("Error stripping s3: %v\n", err)
 			return
 		}
-		if err := integrations.PostmarkStrip(projectName); err != nil {
+		if err := integrations.PostmarkStrip(projectDir); err != nil {
 			cmd.Printf("Error stripping postmark: %v\n", err)
 			return
 		}
-		dcPath := filepath.Join(projectName, "docker-compose.yml")
+
+		dcPath := filepath.Join(projectDir, "docker-compose.yml")
 		dcContent, err := os.ReadFile(dcPath)
 		if err != nil {
 			cmd.Printf("Error reading %s: %v\n", dcPath, err)
 			return
 		}
-		newDcContent := strings.ReplaceAll(string(dcContent), "gofast", projectName)
+		makefilePath := filepath.Join(projectDir, "Makefile")
+		makefileContent, err := os.ReadFile(makefilePath)
+		if err != nil {
+			cmd.Printf("Error reading %s: %v\n", makefilePath, err)
+			return
+		}
+
+		newDcContent := applyProjectName(string(dcContent), projectName)
+		newDcContent, newMakefileContent, err := applyHostPostgresPort(newDcContent, string(makefileContent), postgresPort)
+		if err != nil {
+			cmd.Printf("Error applying Postgres host port: %v\n", err)
+			return
+		}
 		if err := os.WriteFile(dcPath, []byte(newDcContent), 0644); err != nil {
 			cmd.Printf("Error writing to %s: %v\n", dcPath, err)
 			return
 		}
+		if postgresPort != defaultPostgresHostPort {
+			if err := os.WriteFile(makefilePath, []byte(newMakefileContent), 0644); err != nil {
+				cmd.Printf("Error writing to %s: %v\n", makefilePath, err)
+				return
+			}
+		}
 
-		// create gofast.json config using the config package
-		if err := config.Initialize(projectName); err != nil {
+		if err := config.Initialize(projectDir, projectName); err != nil {
 			cmd.Printf("Error creating gofast.json file: %v\n", err)
 			return
 		}
 
-		// run scripts to set up the project
 		cmd.Println("")
 		cmd.Printf("Initializing project '%s'...\n", projectName)
 		scripts := []string{
@@ -160,47 +199,47 @@ var initCmd = &cobra.Command{
 			cmd.Printf("%s\n", messages[i])
 			parts := strings.Fields(script)
 			cmdExec := exec.Command(parts[0], parts[1:]...)
-			cmdExec.Dir = projectName
-			output, err := cmdExec.CombinedOutput()
-			if err != nil {
-				cmd.Printf("Error running '%s': %v\nOutput: %s\n", script, err, output)
+			cmdExec.Dir = projectDir
+			output, runErr := cmdExec.CombinedOutput()
+			if runErr != nil {
+				cmd.Printf("Error running '%s': %v\nOutput: %s\n", script, runErr, output)
 				return
 			}
 		}
 
-		// Format Go code
 		gofmtCmd := exec.Command("go", "fmt", "./...")
-		gofmtCmd.Dir = filepath.Join(projectName, "app", "service-core")
+		gofmtCmd.Dir = filepath.Join(projectDir, "app", "service-core")
 		if output, err := gofmtCmd.CombinedOutput(); err != nil {
 			cmd.Printf("Warning: go fmt failed: %v\nOutput: %s\n", err, output)
 		}
 
-		// Initialize git repo with initial commit
 		gitInitCmd := exec.Command("git", "init")
-		gitInitCmd.Dir = projectName
+		gitInitCmd.Dir = projectDir
 		if output, err := gitInitCmd.CombinedOutput(); err != nil {
 			cmd.Printf("Warning: git init failed: %v\nOutput: %s\n", err, output)
 		}
 		gitAddCmd := exec.Command("git", "add", ".")
-		gitAddCmd.Dir = projectName
+		gitAddCmd.Dir = projectDir
 		if output, err := gitAddCmd.CombinedOutput(); err != nil {
 			cmd.Printf("Warning: git add failed: %v\nOutput: %s\n", err, output)
 		}
 		gitCommitCmd := exec.Command("git", "commit", "-m", "Initial commit")
-		gitCommitCmd.Dir = projectName
+		gitCommitCmd.Dir = projectDir
 		if output, err := gitCommitCmd.CombinedOutput(); err != nil {
 			cmd.Printf("Warning: git commit failed: %v\nOutput: %s\n", err, output)
 		}
+
+		success = true
 
 		cmd.Println("")
 		cmd.Println(config.SuccessStyle.Render("Project '" + projectName + "' initialized successfully!"))
 		cmd.Println("")
 		cmd.Println("Next steps:")
-		cmd.Printf("  1. Run %s\n", config.SuccessStyle.Render("'cd "+projectName+"'"))
+		cmd.Printf("  1. Run %s\n", config.SuccessStyle.Render("'cd "+projectDir+"'"))
 		cmd.Printf("  2. Run %s to start the server\n", config.SuccessStyle.Render("'make start'"))
 		cmd.Println("")
 		cmd.Println("To create a GitHub repo:")
-		cmd.Printf("  %s\n", config.SuccessStyle.Render("gh repo create "+projectName+" --private --source="+projectName+" --push"))
+		cmd.Printf("  %s\n", config.SuccessStyle.Render("gh repo create "+projectName+" --private --source="+projectDir+" --push"))
 		cmd.Println("")
 	},
 }

--- a/cmd/gof/cmd/init_helpers.go
+++ b/cmd/gof/cmd/init_helpers.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultPostgresHostPort = 5432
+	portProbeTimeout        = 200 * time.Millisecond
+)
+
+var projectNamePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
+// parseProjectArg splits a user arg into destination directory and project name.
+func parseProjectArg(arg string) (projectDir string, projectName string, err error) {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return "", "", fmt.Errorf("project path cannot be empty")
+	}
+
+	if strings.HasPrefix(arg, "~/") {
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return "", "", fmt.Errorf("resolving home directory: %w", homeErr)
+		}
+		arg = filepath.Join(home, arg[2:])
+	} else if arg == "~" {
+		return "", "", fmt.Errorf(`project path cannot be "~"; provide a project name or path like ~/myapp`)
+	}
+
+	projectDir = filepath.Clean(arg)
+	projectName = filepath.Base(projectDir)
+	if projectName == "." || projectName == string(filepath.Separator) || projectName == "" {
+		return "", "", fmt.Errorf("could not determine project name from %q", arg)
+	}
+	if !projectNamePattern.MatchString(projectName) {
+		return "", "", fmt.Errorf(
+			"invalid project name %q: must start with a letter and contain only letters, numbers, underscores, or hyphens",
+			projectName,
+		)
+	}
+	return projectDir, projectName, nil
+}
+
+func hostPortInUse(port int) bool {
+	addrs := []string{
+		net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
+		net.JoinHostPort("::1", strconv.Itoa(port)),
+	}
+	for _, addr := range addrs {
+		conn, err := net.DialTimeout("tcp", addr, portProbeTimeout)
+		if err == nil {
+			_ = conn.Close()
+			return true
+		}
+	}
+	return false
+}
+
+// suggestFreePostgresPort finds a free host port to recommend in error messages.
+func suggestFreePostgresPort() int {
+	for port := defaultPostgresHostPort + 1; port <= defaultPostgresHostPort+100; port++ {
+		if !hostPortInUse(port) {
+			return port
+		}
+	}
+	return defaultPostgresHostPort + 1
+}
+
+// applyProjectName rewrites only compose container_name prefixes.
+func applyProjectName(composeContent, projectName string) string {
+	return strings.ReplaceAll(composeContent, "container_name: gofast-", "container_name: "+projectName+"-")
+}
+
+// applyHostPostgresPort rewrites the host-published Postgres port and Makefile DSN port.
+// Internal container POSTGRES_PORT stays 5432.
+// Supports both current templates (port=5432) and legacy templates (no port=).
+func applyHostPostgresPort(composeContent, makefileContent string, hostPort int) (string, string, error) {
+	if hostPort == defaultPostgresHostPort {
+		return composeContent, makefileContent, nil
+	}
+
+	oldPublish := fmt.Sprintf("- %d:%d", defaultPostgresHostPort, defaultPostgresHostPort)
+	newPublish := fmt.Sprintf("- %d:%d", hostPort, defaultPostgresHostPort)
+	if !strings.Contains(composeContent, oldPublish) {
+		return "", "", fmt.Errorf("docker-compose.yml missing expected port mapping %q", oldPublish)
+	}
+	composeContent = strings.Replace(composeContent, oldPublish, newPublish, 1)
+
+	oldDSNPort := fmt.Sprintf("port=%d", defaultPostgresHostPort)
+	newDSNPort := fmt.Sprintf("port=%d", hostPort)
+	switch {
+	case strings.Contains(makefileContent, oldDSNPort):
+		makefileContent = strings.Replace(makefileContent, oldDSNPort, newDSNPort, 1)
+	case strings.Contains(makefileContent, "host=localhost user=postgres"):
+		makefileContent = strings.Replace(
+			makefileContent,
+			"host=localhost user=postgres",
+			fmt.Sprintf("host=localhost port=%d user=postgres", hostPort),
+			1,
+		)
+	default:
+		return "", "", fmt.Errorf("Makefile missing expected migrate DSN (port=%d or host=localhost user=postgres)", defaultPostgresHostPort)
+	}
+
+	return composeContent, makefileContent, nil
+}
+
+func rollbackProject(projectDir string) {
+	down := exec.Command("docker", "compose", "down", "-v")
+	down.Dir = projectDir
+	_ = down.Run()
+	_ = os.RemoveAll(projectDir)
+}

--- a/cmd/gof/config/config.go
+++ b/cmd/gof/config/config.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
 const (
 	SERVER_URL     = "https://admin.gofast.live"
-	VERSION        = "v2.17.0"
+	VERSION        = "v2.18.1"
 	ConfigFileName = "gofast.json"
 )
 
@@ -94,7 +95,7 @@ func AddModel(modelName string, columns []Column) error {
 	return writeConfig(config)
 }
 
-func Initialize(projectName string) error {
+func Initialize(projectDir, projectName string) error {
 	cfg := Config{
 		ProjectName:         projectName,
 		InfraPopulated:      false,
@@ -121,7 +122,7 @@ func Initialize(projectName string) error {
 		return err
 	}
 
-	return os.WriteFile(projectName+"/"+ConfigFileName, data, 0644)
+	return os.WriteFile(filepath.Join(projectDir, ConfigFileName), data, 0644)
 }
 
 func IsSvelte() bool {

--- a/cmd/gof/repo/repo.go
+++ b/cmd/gof/repo/repo.go
@@ -7,53 +7,84 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/gofast-live/gofast-cli/v2/cmd/gof/config"
 )
 
-func DownloadRepo(email string, apiKey string, projectName string) error {
+const (
+	zipFileName     = "gofast-app.zip"
+	extractedPrefix = "gofast-live-gofast-app-"
+)
+
+func DownloadRepo(email string, apiKey string, projectDir string) error {
+	parent := filepath.Dir(projectDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("error creating parent directory %q: %w", parent, err)
+	}
+
 	if os.Getenv("TEST") == "true" {
-		cmd := exec.Command("cp", "-r", "/home/mat/projects/gofast-app", projectName)
-		err := cmd.Run()
-		if err != nil {
+		cmd := exec.Command("cp", "-r", "/home/mat/projects/gofast-app", projectDir)
+		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("error copying test app: %w", err)
 		}
 		return nil
 	}
-	// get the file
-	err := getFile(email, apiKey)
-	if err != nil {
+
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			cleanupDownloadArtifacts(".")
+		}
+	}()
+
+	if err := getFile(email, apiKey); err != nil {
 		return fmt.Errorf("error getting file: %w", err)
 	}
-	// unzip the file
-	err = unzipFile()
-	if err != nil {
+	if err := unzipFile(); err != nil {
 		return fmt.Errorf("error unzipping file: %w", err)
 	}
-	// remove the zip file
-	err = os.Remove("gofast-app.zip")
-	if err != nil {
+	if err := os.Remove(zipFileName); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("error removing zip file: %w", err)
 	}
-	// find and rename the folder `gofast-live-gofast-app-...` to the project name
-	files, err := os.ReadDir(".")
+
+	extracted, err := findExtractedDir(".")
 	if err != nil {
-		return fmt.Errorf("error reading current directory: %w", err)
+		return err
 	}
-	for _, f := range files {
-		if f.IsDir() {
-			if strings.HasPrefix(f.Name(), "gofast-live-gofast-app-") {
-				err = os.Rename(f.Name(), projectName)
-				if err != nil {
-					return err
-				}
-				break
-			}
-		}
+	if err := os.Rename(extracted, projectDir); err != nil {
+		return fmt.Errorf("error renaming template to %q: %w", projectDir, err)
 	}
 
+	succeeded = true
 	return nil
+}
+
+func cleanupDownloadArtifacts(dir string) {
+	_ = os.Remove(filepath.Join(dir, zipFileName))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), extractedPrefix) {
+			_ = os.RemoveAll(filepath.Join(dir, entry.Name()))
+		}
+	}
+}
+
+func findExtractedDir(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("error reading directory %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), extractedPrefix) {
+			return filepath.Join(dir, entry.Name()), nil
+		}
+	}
+	return "", fmt.Errorf("extracted template directory with prefix %q not found", extractedPrefix)
 }
 
 func getFile(email string, apiKey string) error {
@@ -71,29 +102,21 @@ func getFile(email string, apiKey string) error {
 		return fmt.Errorf("error downloading file: %s", resp.Status)
 	}
 	defer func() {
-		err := resp.Body.Close()
-		if err != nil {
+		if err := resp.Body.Close(); err != nil {
 			fmt.Printf("error closing response body: %v\n", err)
 		}
 	}()
 
-	// save the file to the disk
-	_, err = os.Create("gofast-app.zip")
+	file, err := os.OpenFile(zipFileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("error creating file: %w", err)
 	}
-	file, err := os.OpenFile("gofast-app.zip", os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("error opening file: %w", err)
-	}
 	defer func() {
-		err := file.Close()
-		if err != nil {
+		if err := file.Close(); err != nil {
 			fmt.Printf("error closing file: %v\n", err)
 		}
 	}()
-	_, err = io.Copy(file, resp.Body)
-	if err != nil {
+	if _, err = io.Copy(file, resp.Body); err != nil {
 		return fmt.Errorf("error copying response body to file: %w", err)
 	}
 	return nil
@@ -103,13 +126,12 @@ func unzipFile() error {
 	if os.Getenv("TEST") == "true" {
 		return nil
 	}
-	archive, err := zip.OpenReader("gofast-app.zip")
+	archive, err := zip.OpenReader(zipFileName)
 	if err != nil {
 		return fmt.Errorf("error opening zip file: %w", err)
 	}
 	defer func() {
-		err := archive.Close()
-		if err != nil {
+		if err := archive.Close(); err != nil {
 			fmt.Printf("error closing archive: %v\n", err)
 		}
 	}()
@@ -119,35 +141,38 @@ func unzipFile() error {
 			return fmt.Errorf("error opening file in zip: %w", err)
 		}
 
-		defer func() {
-			err := src.Close()
-			if err != nil {
+		if file.FileInfo().IsDir() {
+			if err := src.Close(); err != nil {
 				fmt.Printf("error closing source file: %v\n", err)
 			}
-		}()
-
-		if file.FileInfo().IsDir() {
-			err := os.MkdirAll(file.Name, os.ModePerm)
-			if err != nil {
+			if err := os.MkdirAll(file.Name, os.ModePerm); err != nil {
 				return fmt.Errorf("error creating directory: %w", err)
 			}
 			continue
 		}
 
+		if err := os.MkdirAll(filepath.Dir(file.Name), os.ModePerm); err != nil {
+			_ = src.Close()
+			return fmt.Errorf("error creating parent directory: %w", err)
+		}
+
 		dst, err := os.Create(file.Name)
 		if err != nil {
+			_ = src.Close()
 			return fmt.Errorf("error creating destination file: %w", err)
 		}
-		defer func() {
-			err := dst.Close()
-			if err != nil {
-				fmt.Printf("error closing destination file: %v\n", err)
-			}
-		}()
 
-		_, err = io.Copy(dst, src)
-		if err != nil {
-			return fmt.Errorf("error copying file from zip: %w", err)
+		_, copyErr := io.Copy(dst, src)
+		closeSrcErr := src.Close()
+		closeDstErr := dst.Close()
+		if copyErr != nil {
+			return fmt.Errorf("error copying file from zip: %w", copyErr)
+		}
+		if closeSrcErr != nil {
+			fmt.Printf("error closing source file: %v\n", closeSrcErr)
+		}
+		if closeDstErr != nil {
+			fmt.Printf("error closing destination file: %v\n", closeDstErr)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Split init path vs project name so absolute paths don't become invalid Docker container names
- Fail fast when the Postgres host port is in use, with `--postgres-port` to remap
- Roll back the project directory (and compose resources) if init fails mid-run
- Clean up download/unzip artifacts on failed template fetch
- 
## Test plan
- [ ] `gof init goapp` in an empty dir succeeds
- [ ] `gof init codebase/goapp` uses basename `goapp` for container names
- [ ] With something on `:5432`, init fails and suggests `--postgres-port`
- [ ] Forced mid-init failure leaves no leftover project folder